### PR TITLE
Minor edits to README; add cloning; information order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,29 @@
+# Mover Mate
+
+Mover Mate is a property move organizer. It aids in the organization of property moves, including items, numbers, rooms, hands-on management, and consideration for fragile items.
+
 ## Server-side rendering components
 
 This project is developed using a server-side rendering components approach.
-
-## Mover Mate
-
-It serves as an organizer aimed at aiding in the organization of moves, including items, numbers, rooms, hands-on management, and consideration for fragile items.
 
 This is a project using these tech:
 
 - [Next.js](https://nextjs.org/)
 - [Bun](https://bun.sh/)
 - [Shadcn](https://ui.shadcn.com/)
-- [Talwing](https://tailwindcss.com/)
+- [Tailwind](https://tailwindcss.com/)
 
 ## Getting Started
 
-First, run the development server:
+First, clone and install this repo:
+
+```bash
+git clone https://github.com/jmero01/mover-mate.git
+cd mover-mate
+npm install
+```
+
+Then, run the development server:
 
 ```bash
 bun dev


### PR DESCRIPTION
Just a few edits to the README...

I feel READMEs should always start with a H1 (one hash) and that should describe what the project does. So I moved your engineering content down a little and put what the project does at the top as a H1.
I added a couple more instructions for how to install - just so all the information is there.