### PR TITLE
Simpler boolean logic.

### DIFF
--- a/src/actions/items-actions.tsx
+++ b/src/actions/items-actions.tsx
@@ -12,7 +12,7 @@ export async function createItem(formData: FormData) {
   const fragil = formData.get("fragil")?.toString();
   const hand = formData.get("hand")?.toString();
 
-  if (!number || !color || !content || !room || !fragil || !hand) {
+  if (!(number && color && content && room && fragil && hand)) {
     return;
   }
 
@@ -54,7 +54,7 @@ export async function updateItem(formData: FormData) {
   const fragil = formData.get("fragil")?.toString();
   const hand = formData.get("hand")?.toString();
 
-  if (!id || !room || !number || !content || !color || !fragil || !hand) {
+  if (!(id && room && number && content && color && fragil && hand)) {
     return;
   }
 


### PR DESCRIPTION
One thing to try to improve is the simplicity of our boolean logic. 
Simpler logic leads to fewer bugs and easier understanding.

In this file you had if(!x or !y or !z or ...)

In this PR I simplified to ! (x and y and z and ...). It's the same logical result. But simpler.

Think of each logical operator as one "thing". So each "not" is a thing, and each "or" is a thing, and so on. 
The existing implementation had 2n things. 
Simplified here, it only has one not, and then one and per thing. 1n +1 things. Fewer.

Great understanding of Boolean logic is super helpful. Truth tables are a good place to start if you haven't come across them. https://en.wikipedia.org/wiki/Truth_table